### PR TITLE
lert doesn't run as root, don't use system keytab file

### DIFF
--- a/lert.h
+++ b/lert.h
@@ -25,8 +25,8 @@
 /* where the data base and log are */
 #define LERTS_DATA   "/var/lib/lert/lertdata"
 #define LERTS_LOG    "/var/lib/lert/lertlog"
-#define LERTS_SRVTAB    "/etc/srvtab"
-#define LERTS_KEYTAB    "/etc/krb5.keytab"
+#define LERTS_SRVTAB    "/var/lib/lert/srvtab"
+#define LERTS_KEYTAB    "/var/lib/lert/krb5.keytab"
 
 /* the base name of the displayed files */
 #define LERTS_MSG_FILES   "/afs/athena/system/config/lert/lert"


### PR DESCRIPTION
This concept was lost in:
commit 7e32b2c99cf2fb1aba7380e5ce77de6bb3703ab5
      \* Configure the lert server to comply with the FHS. (Trac: #167)
